### PR TITLE
Allow events with an 'ActionID' to be also handled as Events

### DIFF
--- a/lib/Asterisk/AMI.pm
+++ b/lib/Asterisk/AMI.pm
@@ -973,7 +973,8 @@ sub _handle_packet {
                 #Dispatch depending on packet type
                 if (exists $parsed{'ActionID'}) {
                         $self->_handle_action(\%parsed);
-                } elsif (exists $parsed{'Event'}) {
+                }
+                if (exists $parsed{'Event'}) {
                         $self->_handle_event(\%parsed);
                 }
         }


### PR DESCRIPTION
I ran into an issue where one service emits a UserEvent using `send_action()` and another tries to listen for this event.  Since `send_action()` includes an 'ActionID' field in the event, the receiving side interprets this as an action and will not run the event through the event handlers.

This change allows UserEvents sent via the AMI to be processed by the event handlers.

Thanks!
